### PR TITLE
Fix NetworkError for "Browse contribution" (cherry-picked from inbox)

### DIFF
--- a/packages/SqueakInboxTalk-Core.package/MCFileBasedRepository.extension/instance/versionNamed..st
+++ b/packages/SqueakInboxTalk-Core.package/MCFileBasedRepository.extension/instance/versionNamed..st
@@ -1,0 +1,16 @@
+*SqueakInboxTalk-Core-versions-Monticello-ct.747-override
+versionNamed: aMCVersionName 
+	"For FileBased repositories, aMCVersionName must have the appropriate extension!  :-("
+	| version |
+	version := self cache
+		at: aMCVersionName
+		ifAbsent:
+			[ [ self loadVersionFromFileNamed: aMCVersionName ]
+				on: FileDoesNotExistException , NotFound
+				do: [ : err | nil ] ].
+	self resizeCache: cache.
+	(version notNil and: [ version isCacheable ]) ifTrue:
+		[ cache
+			at: aMCVersionName asMCVersionName
+			put: version ].
+	^ version

--- a/packages/SqueakInboxTalk-Core.package/MCFileBasedRepository.extension/methodProperties.json
+++ b/packages/SqueakInboxTalk-Core.package/MCFileBasedRepository.extension/methodProperties.json
@@ -1,0 +1,5 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"versionNamed:" : "ct 5/7/2021 23:38" } }

--- a/packages/SqueakInboxTalk-Core.package/MCFileBasedRepository.extension/properties.json
+++ b/packages/SqueakInboxTalk-Core.package/MCFileBasedRepository.extension/properties.json
@@ -1,0 +1,2 @@
+{
+	"name" : "MCFileBasedRepository" }

--- a/packages/SqueakInboxTalk-Core.package/MCHttpRepository.extension/instance/webClientDo..st
+++ b/packages/SqueakInboxTalk-Core.package/MCHttpRepository.extension/instance/webClientDo..st
@@ -1,0 +1,51 @@
+*SqueakInboxTalk-Core-private-Monticello-ct.747-override
+webClientDo: aBlock
+
+	| client attemptsLeft response result |
+	self class useSharedWebClientInstance ifTrue: [
+		"Acquire webClient by atomically storing it in the client variable and setting its value to nil."
+		client := webClient.
+		webClient := nil ].
+	
+	client 
+		ifNil: [ client := WebClient new ]
+		ifNotNil: [ 
+			"Attempt to avoid an error by recreating the underlying stream."
+			client isConnected ifFalse: [ client close ] ].
+		
+	attemptsLeft := 3.
+	response := nil.
+	[ response isNil and: [ attemptsLeft > 0 ] ] whileTrue: [
+		response := [ aBlock value: client ]
+			on: NetworkError
+			do: [ :error |
+				attemptsLeft = 0 ifTrue: [ error pass ].
+				(3 - attemptsLeft) seconds asDelay wait.
+				attemptsLeft := attemptsLeft - 1.
+				nil "The response" ] ].	
+	
+	result := (response code between: 200 and: 299) 
+		ifFalse: [
+			response content. "Make sure content is read."
+			nil ]
+		ifTrue: [ 
+			(RWBinaryOrTextStream with: (
+				response contentWithProgress:  [ :total :amount |
+					HTTPProgress new 
+						total: total;
+						amount: amount;
+						signal ])) reset ].
+
+	self class useSharedWebClientInstance
+		ifTrue: [
+			"Save the WebClient instance for reuse, but only if there is no client cached."
+			webClient  
+				ifNil: [ webClient := client ]
+				ifNotNil: [ client close ] ]
+		ifFalse: [ client close ].
+
+	(response code = 404 "Not Found" or: [response code = 410 "Gone"]) ifTrue: [
+		"Need to distinguish between lookup errors and connection errors. Lookup errors will be handled by some senders following the EAFP principle. See #versionNamed:."
+		(NotFound object: response url) signal ].
+	result ifNil: [ NetworkError signal: 'Could not access ', location ].
+	^result

--- a/packages/SqueakInboxTalk-Core.package/MCHttpRepository.extension/methodProperties.json
+++ b/packages/SqueakInboxTalk-Core.package/MCHttpRepository.extension/methodProperties.json
@@ -1,0 +1,5 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"webClientDo:" : "ct 5/7/2021 23:03" } }

--- a/packages/SqueakInboxTalk-Core.package/MCHttpRepository.extension/properties.json
+++ b/packages/SqueakInboxTalk-Core.package/MCHttpRepository.extension/properties.json
@@ -1,0 +1,2 @@
+{
+	"name" : "MCHttpRepository" }


### PR DESCRIPTION
Temporarily copied from Monticello-ct.747 (inbox):

> Fixes a bug in MCHttpRespository(MCFileBasedRepository) >> #versionNamed: that occurred when the repository did not contain the requested version. As the comment in the superclass states, answer nil in this case instead of raising a NetworkError.
> 
> To do this, raise a more precise NotFound error in MCHttpRepository >> #webClientDo: if the version does not exist. I checked all other senders and handlers of the NetworkError; no one else depends on the old behavior.

http://forum.world.st/The-Inbox-Monticello-ct-747-mcz-td5129572.html