### PR TITLE
Revert "Fix CI by referring to fork of squeak-history which can be loaded non-interactively"

### DIFF
--- a/packages/BaselineOfSqueakInboxTalk.package/BaselineOfSqueakInboxTalk.class/instance/baseline..st
+++ b/packages/BaselineOfSqueakInboxTalk.package/BaselineOfSqueakInboxTalk.class/instance/baseline..st
@@ -10,10 +10,7 @@ baseline: spec
 				spec
 					repository: 'github://LinqLover/SimulationStudio/packages';
 					loads: 'SimulationStudio-Base'];
-			baseline: 'SqueakHistory' with: [
-				self flag: #workaround.
-				"Once PR has been accepted, revert to upstream of squeak-history. See: https://github.com/hpi-swa/squeak-history/pull/5"
-				spec repository: 'github://LinqLover/squeak-history:loadable-on-ci/packages'].
+			baseline: 'SqueakHistory' with: [spec repository: 'github://hpi-swa/squeak-history/packages'].
 		"packages"
 		
 		spec

--- a/packages/BaselineOfSqueakInboxTalk.package/BaselineOfSqueakInboxTalk.class/methodProperties.json
+++ b/packages/BaselineOfSqueakInboxTalk.package/BaselineOfSqueakInboxTalk.class/methodProperties.json
@@ -2,7 +2,7 @@
 	"class" : {
 		 },
 	"instance" : {
-		"baseline:" : "ct 5/18/2021 16:53",
+		"baseline:" : "ct 5/20/2021 12:31",
 		"preLoadCore" : "ct 5/18/2021 13:25",
 		"preLoadMailingLists" : "ct 5/18/2021 14:37",
 		"projectClass" : "ct 4/29/2021 23:30" } }


### PR DESCRIPTION
Reverts 33434cc8243ffcc6496cf0a75f84bc5d51f69c7a. https://github.com/hpi-swa/squeak-history/pull/5 now has been merged.