### PR TITLE
Revert "Add missing implementation of MCDictionaryRepository >> #versionNamed: (cherry-picked from inbox)

### DIFF
--- a/packages/SqueakInboxTalkTests.package/MCDictionaryRepository.extension/instance/versionNamed..st
+++ b/packages/SqueakInboxTalkTests.package/MCDictionaryRepository.extension/instance/versionNamed..st
@@ -1,4 +1,0 @@
-*SqueakInboxTalkTests-Core-versions-Monticello-ct.750-override
-versionNamed: aMCVersionName
-
-	^ self versionWithInfo: (dict keys detect: [:info | info name = aMCVersionName] ifNone: [^ nil])

--- a/packages/SqueakInboxTalkTests.package/MCDictionaryRepository.extension/methodProperties.json
+++ b/packages/SqueakInboxTalkTests.package/MCDictionaryRepository.extension/methodProperties.json
@@ -1,5 +1,0 @@
-{
-	"class" : {
-		 },
-	"instance" : {
-		"versionNamed:" : "ct 6/10/2021 18:06" } }

--- a/packages/SqueakInboxTalkTests.package/MCDictionaryRepository.extension/properties.json
+++ b/packages/SqueakInboxTalkTests.package/MCDictionaryRepository.extension/properties.json
@@ -1,2 +1,0 @@
-{
-	"name" : "MCDictionaryRepository" }


### PR DESCRIPTION
This reverts commit 42f9136b75c250278d8b7ee3855d7881b246a044.
Monticello-ct.750 is in the Trunk now.