### PR TITLE
Partially cherry-pick Morphic-ct.1774 from inbox (column-specific tooltips)

### DIFF
--- a/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/instance/balloonText.st
+++ b/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/instance/balloonText.st
@@ -1,0 +1,12 @@
+*SqueakInboxTalk-UI-accessing-Morphic-ct.1774-override
+balloonText
+	
+	| columnIndex modelIndex selector |
+	selector := self getHelpSelector ifNil: [^ super balloonText].
+	(self model respondsTo: selector) ifFalse: [^ nil].
+	
+	modelIndex := self modelIndexFor: self hoverRow.
+	modelIndex > 0 ifFalse: [^ nil].
+	columnIndex := self hoverColumn.
+	columnIndex > 0 ifFalse: [^ nil].
+	^ self model perform: selector withEnoughArguments: {modelIndex. columnIndex}

--- a/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/instance/columnAtLocation..st
+++ b/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/instance/columnAtLocation..st
@@ -1,0 +1,9 @@
+*SqueakInboxTalk-UI-accessing - items-Morphic-ct.1774-override
+columnAtLocation: aPoint
+	"Return the index of the column at the given point or 0 if outside"
+
+	| pointInListMorphCoords |
+	pointInListMorphCoords := (self scroller transformFrom: self) transform: aPoint.
+	
+	^ listMorphs findFirst: [:listMorph |
+		pointInListMorphCoords x between: listMorph left and: listMorph right]

--- a/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/instance/handleMouseMove..st
+++ b/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/instance/handleMouseMove..st
@@ -1,0 +1,8 @@
+*SqueakInboxTalk-UI-events-processing-Morphic-ct.1774-override
+handleMouseMove: anEvent
+
+	anEvent wasHandled ifTrue: [^ self].
+	
+	super handleMouseMove: anEvent.
+	
+	self hoverColumn: (self columnAtLocation: anEvent position).

--- a/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/instance/hoverColumn..st
+++ b/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/instance/hoverColumn..st
@@ -1,0 +1,9 @@
+*SqueakInboxTalk-UI-accessing-Morphic-ct.1774-override
+hoverColumn: viewIndex
+
+	hoverColumn := viewIndex.
+	
+	self wantsBalloon ifTrue: [
+		self activeHand
+			removePendingBalloonFor: self;
+			triggerBalloonFor: self after: self balloonHelpDelayTime].

--- a/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/instance/hoverColumn.st
+++ b/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/instance/hoverColumn.st
@@ -1,0 +1,4 @@
+*SqueakInboxTalk-UI-accessing-Morphic-ct.1774-override
+hoverColumn
+
+	^ hoverColumn ifNil: [0]

--- a/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/instance/hoverRow..st
+++ b/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/instance/hoverRow..st
@@ -1,0 +1,8 @@
+*SqueakInboxTalk-UI-accessing-Morphic-ct.1774-override
+hoverRow: viewIndex
+
+	hoverRow = viewIndex ifTrue: [^ self].
+	hoverRow = 0 ifTrue: [self hoverColumn: 0].
+	listMorphs do: [:listMorph |
+		listMorph rowChanged: hoverRow with: viewIndex].
+	super hoverRow: viewIndex.

--- a/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/methodProperties.json
+++ b/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/methodProperties.json
@@ -1,0 +1,10 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"balloonText" : "ct 6/15/2021 18:31",
+		"columnAtLocation:" : "ct 6/15/2021 18:35",
+		"handleMouseMove:" : "ct 6/15/2021 18:35",
+		"hoverColumn" : "ct 6/15/2021 18:32",
+		"hoverColumn:" : "ct 6/15/2021 18:36",
+		"hoverRow:" : "ct 6/15/2021 18:35" } }

--- a/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/properties.json
+++ b/packages/SqueakInboxTalk.package/PluggableMultiColumnListMorph.extension/properties.json
@@ -1,0 +1,2 @@
+{
+	"name" : "PluggableMultiColumnListMorph" }


### PR DESCRIPTION
> Allows models to honor the currently hovered column position in a PluggableMultiColumnListMorph for mouse actions such as tool-tips or double-click events.

http://forum.world.st/The-Inbox-Morphic-ct-1774-mcz-td5130423.html