### PR TITLE
Fix involvement filters

### DIFF
--- a/packages/SqueakInboxTalk.package/TalkPerson.class/class/current..st
+++ b/packages/SqueakInboxTalk.package/TalkPerson.class/class/current..st
@@ -1,0 +1,4 @@
+accessing
+current: aPerson
+
+	Current := aPerson

--- a/packages/SqueakInboxTalk.package/TalkPerson.class/instance/initializeInteractively.st
+++ b/packages/SqueakInboxTalk.package/TalkPerson.class/instance/initializeInteractively.st
@@ -2,7 +2,7 @@ initialize-release
 initializeInteractively
 
 	self
-		requestLines: 'What e-mail adresses do you use on the inbox?\Enter one per line.' withCRs
+		requestLines: 'What e-mail addresses do you use on the inbox?\Enter one per line.' withCRs
 		initialAnswer: self mailAddresses
 		ifAccepted: [:newAddresses | self mailAddresses: (OrderedCollection withAll: newAddresses)].
 	

--- a/packages/SqueakInboxTalk.package/TalkPerson.class/methodProperties.json
+++ b/packages/SqueakInboxTalk.package/TalkPerson.class/methodProperties.json
@@ -3,6 +3,7 @@
 		"christoph" : "ct 7/3/2021 01:11",
 		"cleanUp" : "ct 7/3/2021 02:16",
 		"current" : "ct 7/3/2021 01:31",
+		"current:" : "ct 7/17/2021 13:01",
 		"currentOrNil" : "ct 7/3/2021 01:46",
 		"hasCurrent" : "ct 7/3/2021 01:50",
 		"marcel" : "ct 7/3/2021 02:25" },

--- a/packages/SqueakInboxTalk.package/TalkPerson.class/methodProperties.json
+++ b/packages/SqueakInboxTalk.package/TalkPerson.class/methodProperties.json
@@ -12,7 +12,7 @@
 		"allAuthorInitials:" : "ct 7/3/2021 01:11",
 		"hasMailAddress:" : "ct 7/7/2021 23:29",
 		"initialize" : "ct 7/3/2021 01:45",
-		"initializeInteractively" : "ct 7/3/2021 01:55",
+		"initializeInteractively" : "ct 7/17/2021 12:56",
 		"mailAddresses" : "ct 6/15/2021 14:44",
 		"mailAddresses:" : "ct 6/15/2021 14:44",
 		"names" : "ct 6/15/2021 14:44",

--- a/packages/SqueakInboxTalk.package/UIManager.extension/instance/multiLineRequest.initialAnswer..st
+++ b/packages/SqueakInboxTalk.package/UIManager.extension/instance/multiLineRequest.initialAnswer..st
@@ -1,0 +1,4 @@
+*SqueakInboxTalk-Core-ui requests
+multiLineRequest: queryString initialAnswer: defaultAnswer
+
+	^ self multiLineRequest: queryString centerAt: self currentHand position initialAnswer: defaultAnswer answerHeight: 200

--- a/packages/SqueakInboxTalk.package/UIManager.extension/methodProperties.json
+++ b/packages/SqueakInboxTalk.package/UIManager.extension/methodProperties.json
@@ -3,4 +3,5 @@
 		 },
 	"instance" : {
 		"edit:label:initialAnswer:shouldStyle:accept:" : "ct 7/14/2021 17:34",
+		"multiLineRequest:initialAnswer:" : "ct 7/3/2021 01:35",
 		"talkChooseMultipleFromLabeledValues:title:" : "ct 7/1/2021 17:15" } }

--- a/packages/SqueakInboxTalkTests.package/TalkInboxBrowserTest.class/instance/testFilterInvolvement.st
+++ b/packages/SqueakInboxTalkTests.package/TalkInboxBrowserTest.class/instance/testFilterInvolvement.st
@@ -1,0 +1,17 @@
+tests
+testFilterInvolvement
+
+	| person |
+	self wrapTest: [:block | | previousPerson |
+		previousPerson := TalkPerson current.
+		block ensure: [TalkPerson current: previousPerson]].
+	TalkPerson current: nil.
+	
+	person := TalkPerson christoph.
+	[self toggleFilter: 'conversations by myself' to: true] valueSupplyingAnswers: {
+		{'*mail addresses*inbox*'. person mailAddresses joinSeparatedBy: Character cr}.
+		{'*author initials*inbox*'. person allAuthorInitials joinSeparatedBy: Character cr}.
+		{'*names*inbox*'. person names joinSeparatedBy: Character cr}}.
+	self waitWhileBusy.
+	
+	self shouldBeFiltered: [:conversation | conversation includesAuthor: person]

--- a/packages/SqueakInboxTalkTests.package/TalkInboxBrowserTest.class/instance/testFilterInvolvement.st
+++ b/packages/SqueakInboxTalkTests.package/TalkInboxBrowserTest.class/instance/testFilterInvolvement.st
@@ -3,7 +3,7 @@ testFilterInvolvement
 
 	| person |
 	self wrapTest: [:block | | previousPerson |
-		previousPerson := TalkPerson current.
+		previousPerson := TalkPerson currentOrNil.
 		block ensure: [TalkPerson current: previousPerson]].
 	TalkPerson current: nil.
 	

--- a/packages/SqueakInboxTalkTests.package/TalkInboxBrowserTest.class/methodProperties.json
+++ b/packages/SqueakInboxTalkTests.package/TalkInboxBrowserTest.class/methodProperties.json
@@ -15,6 +15,7 @@
 		"testFilterContributionStates" : "ct 7/7/2021 22:53",
 		"testFilterContributions" : "ct 7/7/2021 22:53",
 		"testFilterCustom" : "ct 7/7/2021 22:54",
+		"testFilterInvolvement" : "ct 7/17/2021 13:07",
 		"testFilterPackage" : "ct 7/7/2021 22:55",
 		"testRefresh" : "ct 7/8/2021 13:16",
 		"testSearch" : "ct 7/8/2021 00:33",

--- a/packages/SqueakInboxTalkTests.package/TalkInboxBrowserTest.class/methodProperties.json
+++ b/packages/SqueakInboxTalkTests.package/TalkInboxBrowserTest.class/methodProperties.json
@@ -15,7 +15,7 @@
 		"testFilterContributionStates" : "ct 7/7/2021 22:53",
 		"testFilterContributions" : "ct 7/7/2021 22:53",
 		"testFilterCustom" : "ct 7/7/2021 22:54",
-		"testFilterInvolvement" : "ct 7/17/2021 13:07",
+		"testFilterInvolvement" : "ct 7/17/2021 13:12",
 		"testFilterPackage" : "ct 7/7/2021 22:55",
 		"testRefresh" : "ct 7/8/2021 13:16",
 		"testSearch" : "ct 7/8/2021 00:33",


### PR DESCRIPTION
Added a missing `UIManager` extension (d2af34d) and wrote an acceptance regression test to fix interactive `TalkPerson` initialization.

Thanks to @bpieber for reporting this bug!