### PR TITLE
Add support for historic Squeak projects (versions prior to Trunk)

### DIFF
--- a/packages/SqueakInboxTalk.package/TalkInbox.class/class/squeakDev.st
+++ b/packages/SqueakInboxTalk.package/TalkInbox.class/class/squeakDev.st
@@ -2,6 +2,6 @@ accessing
 squeakDev
 
 	^ (self on: TalkMailingList squeakDev)
-		projects: {TalkProject trunk. TalkProject ffi};
+		projects: {TalkProject trunk. TalkProject ffi}, TalkProject squeakVersions reversed;
 		nabbleNodeId: 45488;
 		yourself

--- a/packages/SqueakInboxTalk.package/TalkInbox.class/methodProperties.json
+++ b/packages/SqueakInboxTalk.package/TalkInbox.class/methodProperties.json
@@ -9,7 +9,7 @@
 		"on:" : "ct 5/19/2021 20:54",
 		"sendHtmlMessages" : "ct 7/8/2021 18:03",
 		"sendHtmlMessages:" : "ct 7/8/2021 14:07",
-		"squeakDev" : "ct 7/14/2021 21:16",
+		"squeakDev" : "ct 7/22/2021 02:18",
 		"vmDev" : "ct 7/14/2021 21:20" },
 	"instance" : {
 		"allPackageNames" : "ct 7/7/2021 22:19",

--- a/packages/SqueakInboxTalk.package/TalkProject.class/class/squeakVersionUrls.st
+++ b/packages/SqueakInboxTalk.package/TalkProject.class/class/squeakVersionUrls.st
@@ -1,0 +1,14 @@
+private
+squeakVersionUrls
+
+	| urls |
+	urls := OrderedDictionary new.
+	urls
+		at: '3.9' put: 'http://source.squeak.org/39a';
+		at: '3.10' put: 'http://source.squeak.org/310'.
+	#(4 #(1 2 3 4 5 6) 5 #(0 1 2 3)) pairsDo: [:main :subs |
+		subs do: [:sub |
+			urls
+				at: ('{1}.{2}' format: {main. sub})
+				put: ('http://source.squeak.org/squeak{1}{2}' format: {main. sub})]].
+	^ urls

--- a/packages/SqueakInboxTalk.package/TalkProject.class/class/squeakVersions.st
+++ b/packages/SqueakInboxTalk.package/TalkProject.class/class/squeakVersions.st
@@ -1,0 +1,9 @@
+accessing
+squeakVersions
+
+	^ self squeakVersionUrls associations collect: [:nameAndUrl |
+		Projects at: ('squeak', nameAndUrl key) asLegalSelector asSymbol ifAbsentPut: [
+			self new
+				name: 'Squeak ', nameAndUrl key;
+				trunkRepository: (self findHttpRepository: nameAndUrl value);
+				yourself]]

--- a/packages/SqueakInboxTalk.package/TalkProject.class/class/trunk.st
+++ b/packages/SqueakInboxTalk.package/TalkProject.class/class/trunk.st
@@ -4,7 +4,7 @@ trunk
 	^ Projects at: #trunk ifAbsentPut: [
 		self new
 			name: 'Trunk';
-			trunkRepository: MCRepository trunk labels: #('The Trunk' 'Spur' 'Squeak 4.6');
+			trunkRepository: MCRepository trunk labels: #('The Trunk' 'Spur');
 			inboxRepository: MCRepository inbox label: 'The Inbox';
 			treatedRepository: MCRepository treated label: 'The Treated Inbox';
 			yourself]

--- a/packages/SqueakInboxTalk.package/TalkProject.class/methodProperties.json
+++ b/packages/SqueakInboxTalk.package/TalkProject.class/methodProperties.json
@@ -3,7 +3,9 @@
 		"ffi" : "ct 7/19/2021 13:09",
 		"findHttpRepository:" : "ct 5/8/2021 16:09",
 		"initialize" : "ct 7/19/2021 17:57",
-		"trunk" : "ct 7/19/2021 13:09",
+		"squeakVersionUrls" : "ct 7/22/2021 02:17",
+		"squeakVersions" : "ct 7/22/2021 02:22",
+		"trunk" : "ct 7/22/2021 02:02",
 		"vmMaker" : "ct 7/19/2021 13:09" },
 	"instance" : {
 		"allRepositoryNames" : "ct 7/14/2021 21:25",


### PR DESCRIPTION
Now we should support every relevant project from http://source.squeak.org/.

Fixes the CI on main again which.